### PR TITLE
Return json object that is provided for if statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,7 @@
 - fixed: `min` returning the original minimum value and not the coerced value.
 - fixed: infinite recursive loop for ill formed `in` clauses.
 - fixed: typespec for `resolve/2`.
+- fixed: return json object provided in `if` statements.
+- fixed: return the provided json object if the map size is larger than 1.
 - removed: optional dependencies for `jason` and `poison`.
 - added: Support for `Decimal` to be used.

--- a/test/json_logic_test.exs
+++ b/test/json_logic_test.exs
@@ -461,6 +461,23 @@ defmodule JsonLogicTest do
       logic = %{"if" => [true, "apple", true, "banana", true, "carrot", "date"]}
       assert JsonLogic.resolve(logic) == "apple"
     end
+
+    test "returns object" do
+      logic = %{
+        "if" => [
+          %{"==" => [%{"var" => "foo"}, "bar"]},
+          %{"foo" => "is_bar", "path" => "foo_is_bar"},
+          %{"foo" => "not_bar", "path" => "default_object"}
+        ]
+      }
+
+      data = %{"foo" => "bar"}
+
+      assert %{
+               "foo" => "is_bar",
+               "path" => "foo_is_bar"
+             } == JsonLogic.resolve(logic, data)
+    end
   end
 
   describe "max" do


### PR DESCRIPTION
I was looking at other implementation's errors and have been plugging them into the test suite here. 

- https://github.com/diegoholiveira/jsonlogic/issues/58

I have implemented the same fix that is done for the Go library.